### PR TITLE
トレーニング志向診断のページを作成

### DIFF
--- a/src/app/components/diagnosis.tsx
+++ b/src/app/components/diagnosis.tsx
@@ -39,7 +39,7 @@ export default function Diagnosis({ answers }: Props) {
     }
 
     return (
-        <div className="mt-8">
+        <div className="mt-8 p-6">
             <button
                 className="bg-blue-500 text-white px-4 py-2 rounded"
                 onClick={handleDiagnose}

--- a/src/app/components/diagnosis.tsx
+++ b/src/app/components/diagnosis.tsx
@@ -52,7 +52,7 @@ export default function Diagnosis({ answers }: Props) {
 
             {result && (
                 <div className="mt-6">
-                    <h2 className="text-xl font-bold">あなたのタイプ: {result.type}</h2>
+                    <h2 className="text-xl font-bold">あなたのタイプ: {result.type === "A" ? "筋肥大タイプ" : result.type === "B" ? "筋出力タイプ" : "持久力タイプ"}</h2>
                     <ul className="list-disc ml-6 mt-2">
                         {result.recommendations.map((r, i) => (
                             <li key={i}>{r}</li>

--- a/src/app/components/diagnosis.tsx
+++ b/src/app/components/diagnosis.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState } from 'react'
+
+type Props = {
+    answers: { [id: string]: string }
+}
+
+type Response = {
+    type: string
+    recommendations: string[]
+}
+
+export default function Diagnosis({ answers }: Props) {
+    const [result, setResult] = useState<Response | null>(null)
+    const [error, setError] = useState<string | null>(null)
+
+    const handleDiagnose = async () => {
+        const answerList = Object.values(answers)
+        if (answerList.length === 0) return
+
+        try {
+            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/diagnosis`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ answers: answerList }),
+            })
+
+            if (!res.ok) {
+                throw new Error('診断APIの呼び出しに失敗しました')
+            }
+
+            const data: Response = await res.json()
+            setResult(data)
+            setError(null)
+        } catch (err: any) {
+            setError(err.message || '診断に失敗しました')
+        }
+    }
+
+    return (
+        <div className="mt-8">
+            <button
+                className="bg-blue-500 text-white px-4 py-2 rounded"
+                onClick={handleDiagnose}
+                disabled={Object.values(answers).length === 0}
+            >
+                診断する
+            </button>
+
+            {error && <p className="text-red-500 mt-4">{error}</p>}
+
+            {result && (
+                <div className="mt-6">
+                    <h2 className="text-xl font-bold">あなたのタイプ: {result.type}</h2>
+                    <ul className="list-disc ml-6 mt-2">
+                        {result.recommendations.map((r, i) => (
+                            <li key={i}>{r}</li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/app/components/questions.tsx
+++ b/src/app/components/questions.tsx
@@ -39,7 +39,7 @@ export default function Questions({ onAnswersChangeAction }: Props) {
     }
 
     return (
-        <div>
+        <div className="p-6">
             {questions.map((q) => (
                 <div key={q.id} className="mb-4">
                     <p className="font-semibold">{q.title}</p>

--- a/src/app/components/questions.tsx
+++ b/src/app/components/questions.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export type Option = {
+    label: string
+    type: string
+}
+
+export type Question = {
+    id: string
+    title: string
+    options: Option[]
+}
+
+type Props = {
+    onAnswersChangeAction: (answers: { [id: string]: string }) => void
+}
+
+export default function Questions({ onAnswersChangeAction }: Props) {
+    const [questions, setQuestions] = useState<Question[]>([])
+    const [answers, setAnswers] = useState<{ [id: string]: string }>({})
+
+    useEffect(() => {
+        fetch(`${process.env.NEXT_PUBLIC_API_URL}/questions`)
+            .then(res => res.json())
+            .then(setQuestions)
+            .catch(err => {
+                console.error('質問の取得に失敗しました', err)
+            })
+    }, [])
+
+    useEffect(() => {
+        onAnswersChangeAction(answers)
+    }, [answers, onAnswersChangeAction])
+
+    const handleSelect = (questionId: string, answerType: string) => {
+        setAnswers(prev => ({ ...prev, [questionId]: answerType }))
+    }
+
+    return (
+        <div>
+            {questions.map((q) => (
+                <div key={q.id} className="mb-4">
+                    <p className="font-semibold">{q.title}</p>
+                    {q.options.map((opt, i) => (
+                        <label key={i} className="block">
+                            <input
+                                type="radio"
+                                name={`q-${q.id}`}
+                                value={opt.type}
+                                checked={answers[q.id] === opt.type}
+                                onChange={() => handleSelect(q.id, opt.type)}
+                                className="mr-2"
+                            />
+                            {opt.label}
+                        </label>
+                    ))}
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/src/app/components/questions_and_diagnosis.tsx
+++ b/src/app/components/questions_and_diagnosis.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useState } from 'react'
+import DiagnosisResult from './diagnosis'
+import Questions from './questions'
+
+export default function QuestionsAndDiagnosis() {
+    const [answers, setAnswers] = useState<{ [id: string]: string }>({})
+    return (
+        <>
+            <Questions onAnswersChangeAction={setAnswers} />
+            <DiagnosisResult answers={answers} />
+        </>
+    )
+}

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -1,8 +1,8 @@
-'use server'
-
 import Link from "next/link"
+import QuestionsAndDiagnosis from "../components/questions_and_diagnosis"
 
-export default async function PiramidPage() {
+export default function DiagnosisPage() {
+    // クライアント側のステートが必要なので useState は使わない
     return (
         <main className="p-6">
             <Link className="p-6" href="/">TOPに戻る</Link>
@@ -11,13 +11,10 @@ export default async function PiramidPage() {
                 <p>あなたに向いているトレーニングが何か診断します。</p>
                 <p>質問ごとに3つの選択肢があります。</p>
                 <p>各質問で1つを選択し、診断ボタンを押してください。</p>
-                {/* 質問リストを表示する */}
-                {/* APIはquestions */}
-                {/* 診断ボタン */}
             </div>
-            <div>
-                {/* 診断結果を表示する */}
-                {/* APIはdiagnosis */}
+            <div className="mt-6 space-y-6">
+                {/* クライアント側のステート管理は中のコンポーネントに任せる */}
+                <QuestionsAndDiagnosis />
             </div>
         </main>
     )

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -1,0 +1,24 @@
+'use server'
+
+import Link from "next/link"
+
+export default async function PiramidPage() {
+    return (
+        <main className="p-6">
+            <Link className="p-6" href="/">TOPに戻る</Link>
+            <h1 className='text-2xl font-bold p-6'>トレーニング志向診断</h1>
+            <div className="p-6">
+                <p>あなたに向いているトレーニングが何か診断します。</p>
+                <p>質問ごとに3つの選択肢があります。</p>
+                <p>各質問で1つを選択し、診断ボタンを押してください。</p>
+                {/* 質問リストを表示する */}
+                {/* APIはquestions */}
+                {/* 診断ボタン */}
+            </div>
+            <div>
+                {/* 診断結果を表示する */}
+                {/* APIはdiagnosis */}
+            </div>
+        </main>
+    )
+}


### PR DESCRIPTION
## 関連資料のURL
<!-- なければ貼る必要はなし -->

- https://github.com/y-soliloquy/kintore-pocket-backend/issues/18

## 詳細

- 画面追加
- 質問リストコンポーネント（client）
  - /questionsと通信
- 診断結果表示のコンポーネント（client）
  - /diagnosisと通信

## 挙動確認

- [x] 画面が表示されるか

<img width="731" height="709" alt="スクリーンショット 2025-07-26 20 17 24" src="https://github.com/user-attachments/assets/3a0860cd-ac89-49db-9aad-0789e52d6e56" />

- [x] 診断結果が表示されるか

<img width="347" height="107" alt="スクリーンショット 2025-07-26 20 18 23" src="https://github.com/user-attachments/assets/6e6f75e7-04f5-4603-b2da-16478a58a984" />

## 質問リスト

- [ ] メンテナンスですか？
- [ ] 機能追加ですか？
- [ ] バグフィックスですか？
- [ ] テストは書きましたか？
  - 必要ない場合はその旨を記載

## 共有・注意点など
