### PR TITLE
複数の診断結果に対応する

### DIFF
--- a/src/app/components/diagnosis.tsx
+++ b/src/app/components/diagnosis.tsx
@@ -6,9 +6,19 @@ type Props = {
     answers: { [id: string]: string }
 }
 
-type Response = {
+type Result = {
     type: string
     recommendations: string[]
+}
+
+type Response = {
+    results: Result[]
+}
+
+const typeLabels: Record<string, string> = {
+    A: '筋肥大タイプ',
+    B: '筋出力タイプ',
+    C: '持久力タイプ',
 }
 
 export default function Diagnosis({ answers }: Props) {
@@ -52,12 +62,17 @@ export default function Diagnosis({ answers }: Props) {
 
             {result && (
                 <div className="mt-6">
-                    <h2 className="text-xl font-bold">あなたのタイプ: {result.type === "A" ? "筋肥大タイプ" : result.type === "B" ? "筋出力タイプ" : "持久力タイプ"}</h2>
-                    <ul className="list-disc ml-6 mt-2">
-                        {result.recommendations.map((r, i) => (
-                            <li key={i}>{r}</li>
-                        ))}
-                    </ul>
+                    <h2 className="text-xl font-bold mb-2">あなたのタイプ</h2>
+                    {result.results.map((r, idx) => (
+                        <div key={idx} className="mb-4">
+                            <h3 className="font-semibold">{typeLabels[r.type] || r.type}</h3>
+                            <ul className="list-disc ml-6 mt-1">
+                                {r.recommendations.map((rec, i) => (
+                                    <li key={i}>{rec}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    ))}
                 </div>
             )}
         </div>


### PR DESCRIPTION
## 関連資料のURL
<!-- なければ貼る必要はなし -->

## 詳細

トレーニング志向診断にて複数の結果が返却された際に表示が対応するようにした。

## 挙動確認

- [x] 診断結果が1つの場合、変わらず表示されること

<img width="458" height="375" alt="スクリーンショット 2025-07-27 0 14 46" src="https://github.com/user-attachments/assets/e1f67078-4647-48ac-a3a5-835c9a08fec6" />

<img width="352" height="152" alt="スクリーンショット 2025-07-27 0 14 53" src="https://github.com/user-attachments/assets/17bb855d-bf3e-4309-8704-cde588202d0a" />


- [x] 診断結果が複数の場合、すべてが表示されること

<img width="467" height="380" alt="スクリーンショット 2025-07-27 0 15 30" src="https://github.com/user-attachments/assets/710999a8-fa74-449b-b71b-a831c1c162b9" />

<img width="449" height="314" alt="スクリーンショット 2025-07-27 0 15 40" src="https://github.com/user-attachments/assets/97193878-600f-40d7-a1c9-0128d66cb981" />


## 質問リスト

- [ ] メンテナンスですか？
- [x] 機能追加ですか？
- [ ] バグフィックスですか？
- [ ] テストは書きましたか？
  - 必要ない場合はその旨を記載

## 共有・注意点など
