### PR TITLE
[kaizen]診断するボタンの制御を追加する

### DIFF
--- a/src/app/components/diagnosis.tsx
+++ b/src/app/components/diagnosis.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 
 type Props = {
     answers: { [id: string]: string }
+    totalQuestions: number
+    isReady: boolean
 }
 
 type Result = {
@@ -21,13 +23,13 @@ const typeLabels: Record<string, string> = {
     C: '持久力タイプ',
 }
 
-export default function Diagnosis({ answers }: Props) {
+export default function Diagnosis({ answers, totalQuestions, isReady }: Props) {
     const [result, setResult] = useState<Response | null>(null)
     const [error, setError] = useState<string | null>(null)
 
     const handleDiagnose = async () => {
         const answerList = Object.values(answers)
-        if (answerList.length === 0) return
+        if (answerList.length !== totalQuestions) return
 
         try {
             const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/diagnosis`, {
@@ -53,7 +55,7 @@ export default function Diagnosis({ answers }: Props) {
             <button
                 className="bg-blue-500 text-white px-4 py-2 rounded"
                 onClick={handleDiagnose}
-                disabled={Object.values(answers).length === 0}
+                disabled={!isReady}
             >
                 診断する
             </button>

--- a/src/app/components/diagnosis.tsx
+++ b/src/app/components/diagnosis.tsx
@@ -29,7 +29,11 @@ export default function Diagnosis({ answers, totalQuestions, isReady }: Props) {
 
     const handleDiagnose = async () => {
         const answerList = Object.values(answers)
-        if (answerList.length !== totalQuestions) return
+        // if (answerList.length !== totalQuestions) return
+        if (answerList.length !== totalQuestions) {
+            setError('すべての質問に回答してください')
+            return
+          }
 
         try {
             const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/diagnosis`, {
@@ -59,7 +63,6 @@ export default function Diagnosis({ answers, totalQuestions, isReady }: Props) {
                       : 'bg-gray-300 text-gray-500 cursor-not-allowed'
                   }`}
                 onClick={handleDiagnose}
-                disabled={!isReady}
             >
                 診断する
             </button>

--- a/src/app/components/diagnosis.tsx
+++ b/src/app/components/diagnosis.tsx
@@ -53,7 +53,11 @@ export default function Diagnosis({ answers, totalQuestions, isReady }: Props) {
     return (
         <div className="mt-8 p-6">
             <button
-                className="bg-blue-500 text-white px-4 py-2 rounded"
+                className={`px-4 py-2 rounded ${
+                    isReady
+                      ? 'bg-blue-500 text-white'
+                      : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                  }`}
                 onClick={handleDiagnose}
                 disabled={!isReady}
             >

--- a/src/app/components/questions.tsx
+++ b/src/app/components/questions.tsx
@@ -34,6 +34,16 @@ export default function Questions({ onAnswersChangeAction, onReadyChangeAction, 
 
     useEffect(() => {
         onAnswersChangeAction(answers)
+        const isComplete = questions.length > 0 && Object.keys(answers).length === questions.length
+        onReadyChangeAction(isComplete)
+    }, [answers, questions,onAnswersChangeAction, onReadyChangeAction])
+
+    useEffect(() => {
+        onQuestionCountAction(questions.length)
+    }, [questions, onQuestionCountAction])
+
+    useEffect(() => {
+        onAnswersChangeAction(answers)
     }, [answers, onAnswersChangeAction])
 
     const handleSelect = (questionId: string, answerType: string) => {

--- a/src/app/components/questions.tsx
+++ b/src/app/components/questions.tsx
@@ -15,9 +15,11 @@ export type Question = {
 
 type Props = {
     onAnswersChangeAction: (answers: { [id: string]: string }) => void
+    onReadyChangeAction: (isReady: boolean) => void
+    onQuestionCountAction: (totalQuestions: number) => void
 }
 
-export default function Questions({ onAnswersChangeAction }: Props) {
+export default function Questions({ onAnswersChangeAction, onReadyChangeAction, onQuestionCountAction }: Props) {
     const [questions, setQuestions] = useState<Question[]>([])
     const [answers, setAnswers] = useState<{ [id: string]: string }>({})
 

--- a/src/app/components/questions_and_diagnosis.tsx
+++ b/src/app/components/questions_and_diagnosis.tsx
@@ -8,10 +8,14 @@ export default function QuestionsAndDiagnosis() {
     const [answers, setAnswers] = useState<{ [id: string]: string }>({})
     const [isReady, setIsReady] = useState(false)
     const [totalQuestions, setTotalQuestions] = useState(0)
-    
+
     return (
         <>
-            <Questions onAnswersChangeAction={setAnswers} />
+            <Questions
+                onAnswersChangeAction={setAnswers}
+                onReadyChangeAction={setIsReady}
+                onQuestionCountAction={setTotalQuestions}
+            />
             <DiagnosisResult answers={answers} />
         </>
     )

--- a/src/app/components/questions_and_diagnosis.tsx
+++ b/src/app/components/questions_and_diagnosis.tsx
@@ -16,7 +16,11 @@ export default function QuestionsAndDiagnosis() {
                 onReadyChangeAction={setIsReady}
                 onQuestionCountAction={setTotalQuestions}
             />
-            <DiagnosisResult answers={answers} />
+            <DiagnosisResult
+                answers={answers}
+                totalQuestions={totalQuestions}
+                isReady={isReady}
+            />
         </>
     )
 }

--- a/src/app/components/questions_and_diagnosis.tsx
+++ b/src/app/components/questions_and_diagnosis.tsx
@@ -6,6 +6,9 @@ import Questions from './questions'
 
 export default function QuestionsAndDiagnosis() {
     const [answers, setAnswers] = useState<{ [id: string]: string }>({})
+    const [isReady, setIsReady] = useState(false)
+    const [totalQuestions, setTotalQuestions] = useState(0)
+    
     return (
         <>
             <Questions onAnswersChangeAction={setAnswers} />


### PR DESCRIPTION
## 関連資料のURL
<!-- なければ貼る必要はなし -->

## 詳細

- 全ての選択肢を選択していない状態でボタンがクリックされた場合、エラーメッセージを表示する

## 挙動確認

<img width="358" height="113" alt="スクリーンショット 2025-07-27 14 18 15" src="https://github.com/user-attachments/assets/b4062b1b-e5e6-445e-9968-55bb7b19a6dc" />

## 質問リスト

- [ ] メンテナンスですか？
- [ ] 機能追加ですか？
- [ ] バグフィックスですか？
- [ ] テストは書きましたか？
  - 必要ない場合はその旨を記載

## 共有・注意点など
